### PR TITLE
build: update build generator and target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llama-cpp-sys-3"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "llama.cpp bindings"
 license = "MIT"

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,8 @@ fn main() {
     // Configure
     let mut config = Config::new("external/llama.cpp");
     config
-        .build_target("preinstall")
+        .build_target("install")
+        .generator("Ninja")
         .define("LLAMA_STATIC", "ON")
         .define("LLAMA_STANDALONE", "OFF")
         .define("LLAMA_BUILD_EXAMPLES", "OFF")


### PR DESCRIPTION
Because the Windows build was failing. This should work on all platforms.